### PR TITLE
Potential fix for code scanning alert no. 22: DOM text reinterpreted as HTML

### DIFF
--- a/debug/globe-fill-extrusion.html
+++ b/debug/globe-fill-extrusion.html
@@ -262,7 +262,7 @@ document.getElementById('buildings-fauxao-slider').oninput = function() {
 
 document.getElementById('buildings-ao-radius-slider').oninput = function() {
     map.setPaintProperty("country-boundaries", 'fill-extrusion-ambient-occlusion-radius', this.valueAsNumber);
-    document.getElementById('ao_radius').innerHTML = this.value;
+    document.getElementById('ao_radius').textContent = this.value;
 };
 
 document.getElementById('buildings-opacity-slider').oninput = function() {


### PR DESCRIPTION
Potential fix for [https://github.com/slowedcodinganai/mapbox-gl-js/security/code-scanning/22](https://github.com/slowedcodinganai/mapbox-gl-js/security/code-scanning/22)

To fix the problem, we need to ensure that the value assigned to `innerHTML` is properly escaped to prevent any potential XSS attacks. The best way to do this is to use `textContent` instead of `innerHTML`, as `textContent` will treat the value as plain text rather than HTML, thus preventing any HTML or JavaScript from being executed.

We will replace the use of `innerHTML` with `textContent` on line 265. This change will ensure that the value is safely inserted into the DOM without being interpreted as HTML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
